### PR TITLE
Broken img src on mobile-nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,8 @@
             </div>
             <div class="tpoffcanvas__logo text-center">
                <a href="index.html">
-                  <img src="assets/img/logo/logo-white.png" alt="">
+                  <!-- <img src="assets/img/logo/logo-white.png" alt=""> -->
+                  <img src="assets/img/logo.svg" alt="">
                </a>
             </div>
             <div class="mobile-menu"></div>


### PR DESCRIPTION
Line 180 in index.html had a broken link -- no such folder img/logo exists.  Changed image source to the logo.svg located in assets/img 